### PR TITLE
Add iam role feature to vault provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Usage: vest user-spec command [args]
     VAULT_APP_ROLE
       App role name to use with the kubernetes authentication method.
 
+    VAULT_IAM_ROLE
+      IAM role to request from vault.
+
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.
     

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Usage: vest user-spec command [args]
       App role name to use with the kubernetes authentication method.
 
     VAULT_IAM_ROLE
-      IAM role to request from vault.
+      IAM role to request from vault. If returns credentials, the access key and secret key will be injected into
+      the process environment using the standard environment variables and a credentials file will be written to
+      the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/aws/credentials")
 
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Usage: vest user-spec command [args]
       the process environment using the standard environment variables and a credentials file will be written to
       the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/aws/credentials")
 
+    VAULT_AWS_PATH
+      Mountpoint for the vault AWS secret engine. Defaults to "aws".
+
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.
     

--- a/cmd/vest/doc.go
+++ b/cmd/vest/doc.go
@@ -51,6 +51,9 @@ Usage: {{ .Self }} user-spec command [args]
     VAULT_APP_ROLE
       App role name to use with the kubernetes authentication method.
 
+    VAULT_IAM_ROLE
+      IAM role to request from vault.
+
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.
     

--- a/cmd/vest/doc.go
+++ b/cmd/vest/doc.go
@@ -52,7 +52,9 @@ Usage: {{ .Self }} user-spec command [args]
       App role name to use with the kubernetes authentication method.
 
     VAULT_IAM_ROLE
-      IAM role to request from vault.
+      IAM role to request from vault. If returns credentials, the access key and secret key will be injected into
+      the process environment using the standard environment variables and a credentials file will be written to
+      the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/aws/credentials")
 
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.

--- a/cmd/vest/doc.go
+++ b/cmd/vest/doc.go
@@ -56,6 +56,9 @@ Usage: {{ .Self }} user-spec command [args]
       the process environment using the standard environment variables and a credentials file will be written to
       the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/aws/credentials")
 
+    VAULT_AWS_PATH
+      Mountpoint for the vault AWS secret engine. Defaults to "aws".
+
     VAULT_AUTH_PATH
       Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.
     

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -174,11 +174,7 @@ func (c *Client) AddToEnviron(e *environ.Environ) error {
 				f.WriteString(fmt.Sprintf(awsCredentialsFileFmt, accessKey, secretKey))
 				f.Close()
 				creds["AWS_SHARED_CREDENTIALS_FILE"] = c.AwsCredFile
-			} else {
-				fmt.Printf("open: %v\n", er)
 			}
-		} else {
-			fmt.Printf("mkdir: %v\n", er)
 		}
 
 		e.SafeMerge(creds)

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -103,8 +103,13 @@ func (c *Client) AddToEnviron(e *environ.Environ) error {
 			continue
 		}
 
-		if bits[0] == "" {
-			bits = bits[1:]
+		tail := len(bits) - 1
+		for i := 0; i <= tail; i++ {
+			if bits[i] == "" {
+				bits = append(bits[:i], bits[i+1:tail+1]...)
+				tail--
+				i--
+			}
 		}
 
 		// Add 'data' as the second path element if it does not exist
@@ -149,7 +154,7 @@ func (c *Client) AddToEnviron(e *environ.Environ) error {
 	}
 
 	if c.IamRole != "" {
-		route := "aws/sts/" + c.IamRole
+		route := strings.TrimSpace(strings.Trim(c.AwsPath, "/")) + "/sts/" + strings.TrimSpace(c.IamRole)
 		iam, er := c.Logical().Read(route)
 		if er != nil {
 			return er

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -117,7 +117,7 @@ func TestKeyParser(t *testing.T) {
 	}{
 		{"kv/foo/bar", 1, false},
 		{"/kv/foo/bar:kv/bif/baz", 2, false},
-		{"/kv/foo/bar@1:kv/bif/baz@2", 2, true},
+		{"/kv//foo/bar@1:kv/bif/baz@2", 2, true},
 	}
 
 	for _, test := range tt {

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"github.com/lumoslabs/vestibule/pkg/environ"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,6 +149,7 @@ func TestAddToEnviron(t *testing.T) {
 		{"kv/foo/bar@2", "my-role"},
 	}
 
+	fs = afero.NewMemMapFs()
 	ts := testServer()
 	defer ts.Close()
 
@@ -167,7 +170,7 @@ func TestAddToEnviron(t *testing.T) {
 		e := environ.New()
 		c.AddToEnviron(e)
 		if test.iam != "" {
-			assert.Equal(t, 3, e.Len())
+			assert.Equal(t, 4, e.Len())
 		} else {
 			assert.Equal(t, 1, e.Len())
 		}
@@ -180,6 +183,9 @@ func TestAddToEnviron(t *testing.T) {
 			ak, ok := e.Load("AWS_ACCESS_KEY_ID")
 			assert.True(t, ok)
 			assert.Equal(t, "1234", ak)
+
+			content, _ := afero.ReadFile(fs, awsCredentialsFilePath)
+			assert.Equal(t, fmt.Sprintf(awsCredentialsFileFmt, "1234", "1234"), string(content))
 		}
 
 		os.Unsetenv("VAULT_KV_KEYS")

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -184,7 +184,7 @@ func TestAddToEnviron(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "1234", ak)
 
-			content, _ := afero.ReadFile(fs, awsCredentialsFilePath)
+			content, _ := afero.ReadFile(fs, c.(*Client).AwsCredFile)
 			assert.Equal(t, fmt.Sprintf(awsCredentialsFileFmt, "1234", "1234"), string(content))
 		}
 

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -5,12 +5,13 @@ import "github.com/hashicorp/vault/api"
 // Client is an environ.Provider and github.com/hashicorp/vault/api.Client which will get the requested keys
 type Client struct {
 	*api.Client
-	AuthMethod string `env:"VAULT_AUTH_METHOD" envDefault:"kubernetes"`
-	AuthPath   string `env:"VAULT_AUTH_PATH"`
-	AuthData   string `env:"VAULT_AUTH_DATA" envDefault:"{}"`
-	AppRole    string `env:"VAULT_APP_ROLE"`
-	IamRole    string `env:"VAULT_IAM_ROLE"`
-	Keys       KVKeys `env:"VAULT_KV_KEYS"`
+	AuthMethod  string `env:"VAULT_AUTH_METHOD" envDefault:"kubernetes"`
+	AuthPath    string `env:"VAULT_AUTH_PATH"`
+	AuthData    string `env:"VAULT_AUTH_DATA" envDefault:"{}"`
+	AppRole     string `env:"VAULT_APP_ROLE"`
+	IamRole     string `env:"VAULT_IAM_ROLE"`
+	AwsCredFile string `env:"AWS_SHARED_CREDENTIALS_FILE" envDefault:"/var/aws/credentials"`
+	Keys        KVKeys `env:"VAULT_KV_KEYS"`
 }
 
 // KVKeys is an alias for []*KVKey. Needed for caarlos0/env to support parsing.

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -10,6 +10,7 @@ type Client struct {
 	AuthData    string `env:"VAULT_AUTH_DATA" envDefault:"{}"`
 	AppRole     string `env:"VAULT_APP_ROLE"`
 	IamRole     string `env:"VAULT_IAM_ROLE"`
+	AwsPath     string `env:"VAULT_AWS_PATH" envDefault:"aws"`
 	AwsCredFile string `env:"AWS_SHARED_CREDENTIALS_FILE" envDefault:"/var/aws/credentials"`
 	Keys        KVKeys `env:"VAULT_KV_KEYS"`
 }

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -9,6 +9,7 @@ type Client struct {
 	AuthPath   string `env:"VAULT_AUTH_PATH"`
 	AuthData   string `env:"VAULT_AUTH_DATA" envDefault:"{}"`
 	AppRole    string `env:"VAULT_APP_ROLE"`
+	IamRole    string `env:"VAULT_IAM_ROLE"`
 	Keys       KVKeys `env:"VAULT_KV_KEYS"`
 }
 


### PR DESCRIPTION
Introduce `VAULT_IAM_ROLE` env var. If set, will request credentials for that IAM role from vault and inject them into the environment as the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`