### PR TITLE
Fix logging for realz & Use /var/run

### DIFF
--- a/cmd/bule/log.go
+++ b/cmd/bule/log.go
@@ -10,14 +10,12 @@ type zl struct {
 	zerolog.Logger
 }
 
-func newLogger(level string, writer io.Writer) (l *zl) {
-	l = &zl{zerolog.New(writer).With().Timestamp().Logger()}
+func newLogger(level string, writer io.Writer) *zl {
+	zlog := zerolog.New(writer).With().Timestamp().Logger().Level(zerolog.Disabled)
 	if lvl, er := zerolog.ParseLevel(level); er == nil {
-		l.Level(lvl)
-	} else {
-		l.Logger.Level(zerolog.Disabled)
+		zlog = zlog.Level(lvl)
 	}
-	return
+	return &zl{zlog}
 }
 
 func (l *zl) Info(msg string) {

--- a/cmd/bule/main.go
+++ b/cmd/bule/main.go
@@ -34,7 +34,7 @@ func main() {
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	logLevel := ""
+	logLevel := "disabled"
 	if *debug {
 		logLevel = "debug"
 	}

--- a/cmd/vest/log.go
+++ b/cmd/vest/log.go
@@ -10,14 +10,12 @@ type zl struct {
 	zerolog.Logger
 }
 
-func newLogger(level string, writer io.Writer) (l *zl) {
-	l = &zl{zerolog.New(writer).With().Timestamp().Logger()}
+func newLogger(level string, writer io.Writer) *zl {
+	zlog := zerolog.New(writer).With().Timestamp().Logger().Level(zerolog.Disabled)
 	if lvl, er := zerolog.ParseLevel(level); er == nil {
-		l.Level(lvl)
-	} else {
-		l.Logger.Level(zerolog.Disabled)
+		zlog = zlog.Level(lvl)
 	}
-	return
+	return &zl{zlog}
 }
 
 func (l *zl) Info(msg string) {

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:3.8
 COPY ["bule", "vest", "/bin/"]
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
-  echo 'mkdir -p /var/run/vestibule'; \
-  echo 'bule /var/run/vestibule/secrets || true'; \
+  echo 'mkdir -p /var/run/vestibule && bule /var/run/vestibule/secrets || true'; \
   echo 'exec vest $@'; \
   } >/entrypoint.sh \
   && chmod 755 /entrypoint.sh \ 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.8
 COPY ["bule", "vest", "/bin/"]
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
-  echo 'bule /var/run/secrets.json || true'; \
+  echo 'mkdir -p /var/run/vestibule'; \
+  echo 'bule /var/run/vestibule/secrets || true'; \
   echo 'exec vest $@'; \
   } >/entrypoint.sh \
   && chmod 755 /entrypoint.sh \ 

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 COPY ["bule", "vest", "/bin/"]
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
-  echo 'bule /var/run/secrets.json || true'; \
+  echo 'mkdir -p /var/run/vestibule'; \
+  echo 'bule /var/run/vestibule/secrets || true'; \
   echo 'exec vest $@'; \
   } >/entrypoint.sh \
   && chmod 755 /entrypoint.sh \

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:bionic
 COPY ["bule", "vest", "/bin/"]
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
-  echo 'mkdir -p /var/run/vestibule'; \
-  echo 'bule /var/run/vestibule/secrets || true'; \
+  echo 'mkdir -p /var/run/vestibule && bule /var/run/vestibule/secrets || true'; \
   echo 'exec vest $@'; \
   } >/entrypoint.sh \
   && chmod 755 /entrypoint.sh \

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -46,7 +46,7 @@ type Client struct {
 	AppRole     string `env:"VAULT_APP_ROLE"`
 	IamRole     string `env:"VAULT_IAM_ROLE"`
 	AwsPath     string `env:"VAULT_AWS_PATH" envDefault:"aws"`
-	AwsCredFile string `env:"AWS_SHARED_CREDENTIALS_FILE" envDefault:"/var/aws/credentials"`
+	AwsCredFile string `env:"AWS_SHARED_CREDENTIALS_FILE" envDefault:"/var/run/aws/credentials"`
 	Keys        KVKeys `env:"VAULT_KV_KEYS"`
 }
 


### PR DESCRIPTION
- Logging was not working right, this should fix it
- Put generated files in /var/run by default: `/var/run/vestibule` for secrets ; `/var/run/aws` for aws creds
- Small readability refactor in Vault Provider