### PR TITLE
Vault timeout passthrough

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT = vest
+PROJECT ?= vest
 GOARCH ?= amd64
 REF ?= $(shell git rev-parse --abbrev-ref HEAD)
 SHA ?= $(shell git rev-parse --short=8 HEAD)
@@ -31,5 +31,3 @@ test-all: test test-race test-memory
 linux darwin:
 	@echo "==> Building $(PROJECT)-$@-$(GOARCH)		ref=$(REF) sha=$(SHA) out=$(OUT_DIR)/$(PROJECT)-$@-$(GOARCH)"
 	@GOOS=$@ GOARCH=$(GOARCH) go build $(BUILD_FLAGS) -ldflags $(LINK_FLAGS) -o $(OUT_DIR)/$(PROJECT)-$@-$(GOARCH) ./cmd/$(PROJECT)
-
-

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -53,9 +53,9 @@ func New() (environ.Provider, error) {
 
 	log.Debugf("Creating vault api client. addr=%v", os.Getenv("VAULT_ADDR"))
 	vaultConfig := api.DefaultConfig()
-	vaultConfig.Timeout = time.Second * 3
-	vaultConfig.HttpClient.Timeout = time.Second * 3
-	vaultConfig.MaxRetries = 1
+	vaultConfig.Timeout = time.Second * 5
+	vaultConfig.HttpClient.Timeout = time.Second * 5
+	vaultConfig.MaxRetries = 2
 	vc, er := api.NewClient(vaultConfig)
 	if er != nil {
 		return nil, er

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -52,10 +52,17 @@ func New() (environ.Provider, error) {
 	}()
 
 	log.Debugf("Creating vault api client. addr=%v", os.Getenv("VAULT_ADDR"))
+	clientTimeout, timeoutErr := time.ParseDuration(os.Getenv("VAULT_CLIENT_TIMEOUT"))
+	clientMaxRetries, maxRetryErr := strconv.Atoi(os.Getenv("VAULT_MAX_RETRIES"))
 	vaultConfig := api.DefaultConfig()
-	vaultConfig.Timeout = time.Second * 5
-	vaultConfig.HttpClient.Timeout = time.Second * 5
-	vaultConfig.MaxRetries = 2
+	if timeoutErr != nil {
+		clientTimeout = time.Second * 3
+	}
+	if maxRetryErr != nil {
+		clientMaxRetries = 1
+	}
+	vaultConfig.HttpClient.Timeout = clientTimeout
+	vaultConfig.MaxRetries = clientMaxRetries
 	vc, er := api.NewClient(vaultConfig)
 	if er != nil {
 		return nil, er

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -52,24 +52,31 @@ func New() (environ.Provider, error) {
 	}()
 
 	log.Debugf("Creating vault api client. addr=%v", os.Getenv("VAULT_ADDR"))
-	clientTimeout, timeoutErr := time.ParseDuration(os.Getenv("VAULT_CLIENT_TIMEOUT"))
-	clientMaxRetries, maxRetryErr := strconv.Atoi(os.Getenv("VAULT_MAX_RETRIES"))
-	vaultConfig := api.DefaultConfig()
-	if timeoutErr != nil {
+
+	clientTimeout, err := time.ParseDuration(os.Getenv("VAULT_CLIENT_TIMEOUT"))
+
+	if err != nil {
 		clientTimeout = time.Second * 3
 	}
-	if maxRetryErr != nil {
+
+	clientMaxRetries, err := strconv.Atoi(os.Getenv("VAULT_MAX_RETRIES"))
+
+	if err != nil {
 		clientMaxRetries = 1
 	}
+
+	vaultConfig := api.DefaultConfig()
 	vaultConfig.HttpClient.Timeout = clientTimeout
 	vaultConfig.MaxRetries = clientMaxRetries
 	vc, er := api.NewClient(vaultConfig)
+
 	if er != nil {
 		return nil, er
 	}
 
 	v := &Client{Client: vc}
 	p := env.CustomParsers{reflect.TypeOf(KVKeys{}): vaultKeyParser}
+
 	if er := env.ParseWithFuncs(v, p); er != nil {
 		return nil, er
 	}

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -170,6 +170,9 @@ func TestAddToEnviron(t *testing.T) {
 			os.Setenv("VAULT_IAM_ROLE", test.iam)
 		}
 
+		os.Setenv("VAULT_CLIENT_TIMEOUT", "5s")
+		os.Setenv("VAULT_MAX_RETRIES", "1")
+
 		c, er := New()
 		require.NoError(t, er)
 
@@ -199,5 +202,7 @@ func TestAddToEnviron(t *testing.T) {
 
 		os.Unsetenv("VAULT_KV_KEYS")
 		os.Unsetenv("VAULT_IAM_ROLE")
+		os.Unsetenv("VAULT_CLIENT_TIMEOUT")
+		os.Unsetenv("VAULT_MAX_RETRIES")
 	}
 }

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -170,9 +170,6 @@ func TestAddToEnviron(t *testing.T) {
 			os.Setenv("VAULT_IAM_ROLE", test.iam)
 		}
 
-		os.Setenv("VAULT_CLIENT_TIMEOUT", "5s")
-		os.Setenv("VAULT_MAX_RETRIES", "1")
-
 		c, er := New()
 		require.NoError(t, er)
 
@@ -202,7 +199,5 @@ func TestAddToEnviron(t *testing.T) {
 
 		os.Unsetenv("VAULT_KV_KEYS")
 		os.Unsetenv("VAULT_IAM_ROLE")
-		os.Unsetenv("VAULT_CLIENT_TIMEOUT")
-		os.Unsetenv("VAULT_MAX_RETRIES")
 	}
 }

--- a/pkg/environ/providers/vault/main_test.go
+++ b/pkg/environ/providers/vault/main_test.go
@@ -164,6 +164,9 @@ func TestAddToEnviron(t *testing.T) {
 		os.Unsetenv("VAULT_ADDR")
 	}()
 
+	// Prevents this from getting passed through from higher process' env.
+	os.Unsetenv("VAULT_IAM_ROLE")
+
 	for _, test := range tt {
 		os.Setenv("VAULT_KV_KEYS", test.keys)
 		if test.iam != "" {


### PR DESCRIPTION
Passes through the built-in vault EVs for timeouts and retry but sets more sane defaults for vest/bule.