### PR TITLE
Token Expose Ability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,4 @@
+---
 stages:
   - test
   - release
@@ -26,8 +27,7 @@ test:memory:
 release:test:
   extends: .base
   stage: release
-  services:
-    - docker:dind
+  services: ["docker:18.09-dind"]
   variables:
     DOCKER_HOST: tcp://127.0.0.1:2375/
     DOCKER_DRIVER: overlay2
@@ -39,10 +39,8 @@ release:test:
 release:
   extends: .base
   stage: release
-  only:
-    - tags
-  services:
-    - docker:dind
+  only: [tags]
+  services: ["docker:18.09-dind"]
   variables:
     DOCKER_HOST: tcp://127.0.0.1:2375/
     DOCKER_DRIVER: overlay2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - release
 
 .base:
-  image: registry.gitlab.com/lumoslabs/docker-library/golang:1.12-ci-9d7f4c8f
+  image: registry.gitlab.com/lumoslabs/docker-library/golang:1.13-stretch-ci
   variables:
     GIT_DEPTH: "3"
     GOFLAGS: -mod=vendor

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+---
 builds:
   - env: ["CGO_ENABLED=0"]
     main: ./cmd/vest
@@ -9,6 +10,7 @@ builds:
     binary: bule
     asmflags: ["all=-trimpath={{.Env.PWD}}"]
     gcflags: ["all=-trimpath={{.Env.PWD}}"]
+
 archives:
   - files: ["none*"]
     replacements:
@@ -17,31 +19,35 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
+
 snapshot:
   name_template: "{{ .Tag }}-snapshot"
+
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
+
 release:
   prerelease: auto
 
-brew:
-  skip_upload: auto
-  github:
-    owner: lumoslabs
-    name: homebrew-vestibule
-  
-  folder: Formula
-  description: "Gather secrets from various backends and inject them into the process environment"
-  homepage: "https://github.com/lumoslabs/vestibule"
-  test: |
-    system "#{bin}/vest --version"
-    system "#{bin}/bule --version"
+# brew:
+#   skip_upload: auto
+#   github:
+#     owner: lumoslabs
+#     name: homebrew-vestibule
+
+#   folder: Formula
+#   description: "Gather secrets from various backends and inject them into the process environment"
+#   homepage: "https://github.com/lumoslabs/vestibule"
+#   test: |
+#     system "#{bin}/vest --version"
+#     system "#{bin}/bule --version"
 
 dockers:
   - dockerfile: docker/alpine/Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,11 +5,13 @@ builds:
     binary: vest
     asmflags: ["all=-trimpath={{.Env.PWD}}"]
     gcflags: ["all=-trimpath={{.Env.PWD}}"]
+    id: vestibule-vest
   - env: ["CGO_ENABLED=0"]
     main: ./cmd/bule
     binary: bule
     asmflags: ["all=-trimpath={{.Env.PWD}}"]
     gcflags: ["all=-trimpath={{.Env.PWD}}"]
+    id: vestibule-bule
 
 archives:
   - files: ["none*"]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,18 +38,17 @@ changelog:
 release:
   prerelease: auto
 
-# brew:
-#   skip_upload: auto
-#   github:
-#     owner: lumoslabs
-#     name: homebrew-vestibule
-
-#   folder: Formula
-#   description: "Gather secrets from various backends and inject them into the process environment"
-#   homepage: "https://github.com/lumoslabs/vestibule"
-#   test: |
-#     system "#{bin}/vest --version"
-#     system "#{bin}/bule --version"
+brews:
+  - skip_upload: auto
+    github:
+      owner: lumoslabs
+      name: homebrew-vestibule
+    folder: Formula
+    description: "Gather secrets from various backends and inject them into the process environment"
+    homepage: "https://github.com/lumoslabs/vestibule"
+    test: |
+      system "#{bin}/vest --version"
+      system "#{bin}/bule --version"
 
 dockers:
   - dockerfile: docker/alpine/Dockerfile

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,10 +1,13 @@
 FROM alpine:3.8
+
 COPY ["bule", "vest", "/bin/"]
+
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
   echo 'mkdir -p /var/run/vestibule && bule /var/run/vestibule/secrets || true'; \
   echo 'exec vest $@'; \
   } >/entrypoint.sh \
-  && chmod 755 /entrypoint.sh \ 
+  && chmod 755 /entrypoint.sh \
   && apk add --update dumb-init jq ca-certificates
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:bionic
+
 COPY ["bule", "vest", "/bin/"]
+
 RUN { \
   echo '#!/usr/bin/dumb-init /bin/sh'; \
   echo 'mkdir -p /var/run/vestibule && bule /var/run/vestibule/secrets || true'; \
@@ -8,4 +10,5 @@ RUN { \
   && chmod 755 /entrypoint.sh \
   && apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dumb-init jq ca-certificates
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/go.mod
+++ b/go.mod
@@ -105,3 +105,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -135,7 +135,7 @@ github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a h1:z9eTtDWoxYr
 github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a/go.mod h1:Ft7ju2vWzhO0ETMKUVo12XmXmII6eSUS4rsPTkY/siA=
 github.com/hashicorp/go-retryablehttp v0.5.1 h1:Vsx5XKPqPs3M6sM4U4GWyUqFS8aBiL9U5gkgvpkg4SE=
 github.com/hashicorp/go-retryablehttp v0.5.1/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-rootcerts v1.0.0 h1:ueI78wUjYExhCvMLow4icJnayNNFRgy0d9EGs/a1T44=
+github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.1 h1:eCkkJ5KOOktDvwbsE9KPyiBWaOfp1ZNy2gLHgL8PSBM=
 github.com/hashicorp/go-sockaddr v1.0.1/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/pkg/environ/providers/vault/main.go
+++ b/pkg/environ/providers/vault/main.go
@@ -263,6 +263,12 @@ func (client *Client) AddToEnviron(env *environ.Environ) error {
 		}(strings.TrimSpace(strings.Trim(client.GcpPath, "/")) + "/" + client.GcpCredType + "/" + strings.TrimSpace(client.GcpRole))
 	}
 
+	if client.ExposeToken {
+		vaultToken := make(map[string]string)
+		vaultToken["VAULT_TOKEN"] = client.Token()
+		env.SafeMerge(vaultToken)
+	}
+
 	wg.Wait()
 	return nil
 }

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -29,6 +29,7 @@ const (
 	EnvVaultGcpPath          = "VAULT_GCP_PATH"
 	EnvVaultGcpRole          = "VAULT_GCP_ROLE"
 	EnvVaultKeys             = "VAULT_KV_KEYS"
+	EnvVestExposeVaultToken  = "VEST_VAULT_EXPOSE_TOKEN"
 )
 
 var (
@@ -60,21 +61,22 @@ e.g. VAULT_KV_KEYS=/path/to/key1[@version]:/path/to/key2[@version]:...`,
 		EnvVaultAwsRole: `Name of the aws role to generate credentials against. If credentials are returned, the access key and secret key will be injected into
 the process environment using the standard environment variables and a credentials file will be written to
 the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/run/aws/credentials")`,
-		"VAULT_*":            "All vault client configuration environment variables are respected. More information at https://www.vaultproject.io/docs/commands/#environment-variables",
-		EnvVaultIamRole:      "[DEPRECATED] Name of the aws role to generate credentials against.",
-		EnvAwsProfile:        `AWS profile to use in the shared credentials file. Defaults to "default"`,
-		EnvAwsSharedCredFile: `Path to the AWS shared credentials file to write credentials to. Defaults to "/var/run/aws/credentials"`,
-		EnvGoogleCredFile:    `Path to the GCP service account credentials file to create. Defaults to "/var/run/gcp/creds.json"`,
-		EnvVaultAppJWT:       "The jwt for use with OIDC/JWT authentication",
-		EnvVaultAppRole:      "Either the role id for AppRole authentication, or the role name fo Kubernetes authentication.",
-		EnvVaultAppSecret:    "The secret id for use with AppRole authentication",
-		EnvVaultAuthData:     "Data payload to send with authentication request. JSON object.",
-		EnvVaultAuthMethod:   `Authentication method for vault. Default is "kubernetes".`,
-		EnvVaultAuthPath:     "Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.",
-		EnvVaultAwsPath:      `Mountpoint for the vault AWS secret engine. Defaults to "aws".`,
-		EnvVaultGcpCredType:  "GCP credential type to generate. Defaults to key. Accepted values are [token key]",
-		EnvVaultGcpPath:      `Mountpoint for the vault GCP secret engine. Defaults to "gcp".`,
-		EnvVaultGcpRole:      "Name of the GCP role in vault to generate credentials against.",
+		"VAULT_*":               "All vault client configuration environment variables are respected. More information at https://www.vaultproject.io/docs/commands/#environment-variables",
+		EnvVaultIamRole:         "[DEPRECATED] Name of the aws role to generate credentials against.",
+		EnvAwsProfile:           `AWS profile to use in the shared credentials file. Defaults to "default"`,
+		EnvAwsSharedCredFile:    `Path to the AWS shared credentials file to write credentials to. Defaults to "/var/run/aws/credentials"`,
+		EnvGoogleCredFile:       `Path to the GCP service account credentials file to create. Defaults to "/var/run/gcp/creds.json"`,
+		EnvVaultAppJWT:          "The jwt for use with OIDC/JWT authentication",
+		EnvVaultAppRole:         "Either the role id for AppRole authentication, or the role name fo Kubernetes authentication.",
+		EnvVaultAppSecret:       "The secret id for use with AppRole authentication",
+		EnvVaultAuthData:        "Data payload to send with authentication request. JSON object.",
+		EnvVaultAuthMethod:      `Authentication method for vault. Default is "kubernetes".`,
+		EnvVaultAuthPath:        "Authentication path for vault authentication - e.g. okta/login/:user. Overrides VAULT_AUTH_METHOD if set.",
+		EnvVaultAwsPath:         `Mountpoint for the vault AWS secret engine. Defaults to "aws".`,
+		EnvVaultGcpCredType:     "GCP credential type to generate. Defaults to key. Accepted values are [token key]",
+		EnvVaultGcpPath:         `Mountpoint for the vault GCP secret engine. Defaults to "gcp".`,
+		EnvVaultGcpRole:         "Name of the GCP role in vault to generate credentials against.",
+		EnvVestExposeVaultToken: "Should we expose the resulting vault token for the sub-process (potentially insecure! use with caution!)?",
 	}
 )
 

--- a/pkg/environ/providers/vault/types.go
+++ b/pkg/environ/providers/vault/types.go
@@ -76,7 +76,7 @@ the path from AWS_SHARED_CREDENTIALS_FILE (by default "/var/run/aws/credentials"
 		EnvVaultGcpCredType:     "GCP credential type to generate. Defaults to key. Accepted values are [token key]",
 		EnvVaultGcpPath:         `Mountpoint for the vault GCP secret engine. Defaults to "gcp".`,
 		EnvVaultGcpRole:         "Name of the GCP role in vault to generate credentials against.",
-		EnvVestExposeVaultToken: "Should we expose the resulting vault token for the sub-process (potentially insecure! use with caution!)?",
+		EnvVestExposeVaultToken: "Should we expose the resulting vault token, even if vest generated it, for the sub-process? (POTENTIALLY INSECURE -- USE WITH CAUTION!)",
 	}
 )
 
@@ -98,6 +98,7 @@ type Client struct {
 	GcpRole     string              `env:"VAULT_GCP_ROLE"`
 	GcpCredType string              `env:"VAULT_GCP_CRED_TYPE" envDefault:"key"`
 	GcpCredFile string              `env:"GOOGLE_CREDENTIALS_FILE" envDefault:"/var/run/gcp/creds.json"`
+	ExposeToken bool                `env:"VEST_VAULT_EXPOSE_TOKEN" envDefault:false`
 	Keys        []KVKey             `env:"VAULT_KV_KEYS" envSeparator:":"`
 }
 


### PR DESCRIPTION
This feature allows one to force the `$VAULT_TOKEN` variable to either get re-exported, or exported (if vest generates it via another means) so that the sub-process can do as it wishes with the credentials that vestibule originally had.

*NOTE:* more than likely this token will expire [depending on the role/policy used with vestibule], and is mostly to allow sub-processes of vest to do actions that vestibule might not support immediately, against vault.

The main goal of this feature is allowing vestibule to act as a login proxy for vault, ultimately leaving it up to the sub-process to do what it needs/wants with vault.