### PR TITLE
Add GitHub Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+## Security
+Lumos Labs takes the security of our software products and services seriously, which includes all source code repositories managed through our [Lumos Labs GitHub organization](https://github.com/lumoslabs).
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+## Responsible Disclosure Policy
+Lumos Labs is deeply committed to the security of our services and our users’ information. If you are a security researcher and have discovered a security vulnerability in one of our services, we appreciate your help in disclosing it to us in a responsible manner.
+
+Lumos Labs will engage with security researchers who report vulnerabilities to us in accordance with this Responsible Disclosure Policy.
+
+## Prohibited Actions
+Lumos Labs prohibits individuals from accessing, downloading or modifying data residing in any account that does not belong to that individual. The following actions are also prohibited:
+
+* Executing or attempting to execute any denial of service attack;
+* Knowingly posting, transmitting, uploading, linking to, sending, or storing any malicious software on or through Lumos Labs services;
+* Sending or causing the sending of spam messages or other unsolicited messages to users;
+* Testing in a manner that would degrade the operation of our services; or
+* Any other testing that violates applicable law or our Terms of Service.
+
+## Reporting
+Please share the details of any suspected or detected vulnerabilities with the Lumos Labs Security Team by emailing disclosure@lumoslabs.com. For the security of our users and service, we ask that you do not publicly disclose these details without express written consent from Lumos Labs. In reporting any suspected vulnerability, please include the following information:
+
+* Your name and email address;
+* Vulnerability details with information to allow us to efficiently reproduce your steps; and
+
+## Our Commitment
+If we verify a security vulnerability that you report to us in compliance with this Policy, we commit to:
+
+* Promptly acknowledging the receipt of your report;
+* Providing you the status of your report; and
+* Notifying you when the vulnerability is fixed.
+* Safe Harbor
+
+Any activities conducted in a manner consistent with our policies will be considered authorized conduct and we will not initiate legal action against you. If legal action is initiated by a third party against you in connection with activities conducted under this policy, we will take steps to make it known that your actions were conducted in compliance with this policy.
+
+Thank you for helping keep Lumosity and our users safe!


### PR DESCRIPTION
This adds a contributing guide and security policy for the `[vestibule](https://github.com/lumoslabs/vestibule)` repository.

➡️  **This update bears no changes to the port's features and functionality.**

I mostly used the content already written in Lumos Labs' [Responsible Disclosure Policy](https://www.lumosity.com/en/legal/responsible_disclosure_policy/)

## Benefits
Adding a security policy will enable the Security Policy option under the Security tab in GitHub. These are also indexed by various platforms that scrape GitHub for OSS project metadata.
![image](https://github.com/lumoslabs/vestibule/assets/34169713/9fdcf930-9a3a-475c-b563-0c6021a8c263)
